### PR TITLE
Changed order of execution depending on up- or downscaling

### DIFF
--- a/src/Azure/BudgetSaver/tools/azure-costs-saver.psm1
+++ b/src/Azure/BudgetSaver/tools/azure-costs-saver.psm1
@@ -546,8 +546,35 @@ function Set-ResourceSizesForCostsSaving {
         Exit $false;
     }
 
-    ProcessWebApps -webAppFarms $resources.where( {$_.ResourceType -eq "Microsoft.Web/serverFarms" -And $_.ResourceGroupName -eq "$ResourceGroupName"}) -logStringFormat $logStringFormat -ResourceGroupName $ResourceGroupName;
-    ProcessSqlDatabases -sqlServers $resources.where( {$_.ResourceType -eq "Microsoft.Sql/servers" -And $_.ResourceGroupName -eq "$ResourceGroupName"}) -logStringFormat $logStringFormat -ResourceGroupName $ResourceGroupName;
-    ProcessVirtualMachines -vms $resources.where( {$_.ResourceType -eq "Microsoft.Compute/virtualMachines" -And $_.ResourceGroupName -eq "$ResourceGroupName"}) -logStringFormat $logStringFormat -ResourceGroupName $ResourceGroupName;
-    ProcessVirtualMachinesScaleSets -vmScaleSets $resources.where( {$_.ResourceType -eq "Microsoft.Compute/virtualMachineScaleSets" -And $_.ResourceGroupName -eq "$ResourceGroupName"}) -logStringFormat $logStringFormat -ResourceGroupName $ResourceGroupName;
+    function ExecuteProcessSqlDatabase()
+    {
+        ProcessSqlDatabases -sqlServers $resources.where( {$_.ResourceType -eq "Microsoft.Sql/servers" -And $_.ResourceGroupName -eq "$ResourceGroupName"}) -logStringFormat $logStringFormat -ResourceGroupName $ResourceGroupName;
+    }
+    function ExecuteProcessWebApps()
+    {
+        ProcessWebApps -webAppFarms $resources.where( {$_.ResourceType -eq "Microsoft.Web/serverFarms" -And $_.ResourceGroupName -eq "$ResourceGroupName"}) -logStringFormat $logStringFormat -ResourceGroupName $ResourceGroupName;
+    }
+    function ExecuteProcessVirtualMachines()
+    {
+        ProcessVirtualMachines -vms $resources.where( {$_.ResourceType -eq "Microsoft.Compute/virtualMachines" -And $_.ResourceGroupName -eq "$ResourceGroupName"}) -logStringFormat $logStringFormat -ResourceGroupName $ResourceGroupName;
+    }
+    function ExecuteProcessVirtualMachinesScaleSets()
+    {
+        ProcessVirtualMachinesScaleSets -vmScaleSets $resources.where( {$_.ResourceType -eq "Microsoft.Compute/virtualMachineScaleSets" -And $_.ResourceGroupName -eq "$ResourceGroupName"}) -logStringFormat $logStringFormat -ResourceGroupName $ResourceGroupName;
+    }
+
+    if($Upscale)
+    {
+        ExecuteProcessSqlDatabase;
+        ExecuteProcessWebApps;
+        ExecuteProcessVirtualMachines;
+        ExecuteProcessVirtualMachinesScaleSets;
+    }
+    if($Downscale)
+    {   
+        ExecuteProcessWebApps;
+        ExecuteProcessVirtualMachines;
+        ExecuteProcessVirtualMachinesScaleSets;
+        ExecuteProcessSqlDatabase;        
+    }
 }


### PR DESCRIPTION
Hi Anton,

Currently we experiencing problems with our sitecore webapps when downscaling the databases first, causing the still upscaled nodes to experience database connectivity problems (because of the lower DTU/tier settings). I took the liberty to create a PR with the change of execution order depending on the up- or downscaling scenario.

Hopefully you can merge this into master and incorporate this into the latest release.
Unfortunately I have no possibility to test this.

Please let me know what you think about this change?

Greetings,

Erik Faber
We Are you 

