### PR TITLE
Bug-fix upscaling not working: Replace nonexistent $Upscale

### DIFF
--- a/src/Azure/BudgetSaver/tools/azure-costs-saver.psm1
+++ b/src/Azure/BudgetSaver/tools/azure-costs-saver.psm1
@@ -563,18 +563,16 @@ function Set-ResourceSizesForCostsSaving {
         ProcessVirtualMachinesScaleSets -vmScaleSets $resources.where( {$_.ResourceType -eq "Microsoft.Compute/virtualMachineScaleSets" -And $_.ResourceGroupName -eq "$ResourceGroupName"}) -logStringFormat $logStringFormat -ResourceGroupName $ResourceGroupName;
     }
 
-    if($Upscale)
-    {
-        ExecuteProcessSqlDatabase;
-        ExecuteProcessWebApps;
-        ExecuteProcessVirtualMachines;
-        ExecuteProcessVirtualMachinesScaleSets;
-    }
-    if($Downscale)
-    {   
+    if($Downscale){   
         ExecuteProcessWebApps;
         ExecuteProcessVirtualMachines;
         ExecuteProcessVirtualMachinesScaleSets;
         ExecuteProcessSqlDatabase;        
+    }
+	else {
+        ExecuteProcessSqlDatabase;
+        ExecuteProcessWebApps;
+        ExecuteProcessVirtualMachines;
+        ExecuteProcessVirtualMachinesScaleSets;
     }
 }


### PR DESCRIPTION
Found a bug which causes upscaling not to work ($Upscaling var is a non-existent var).
Create a fix which evaluates the $Downscaling bool

plz merge as soon as possible.

Thank you!

Erik
We Are You